### PR TITLE
Add robots.txt to disallow all crawling

### DIFF
--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tests/hexo.test.mjs
+++ b/tests/hexo.test.mjs
@@ -34,6 +34,11 @@ describe('Hexo build', () => {
     console.log(`  Generated ${files.length} files/directories`);
   });
 
+  test('Verify robots.txt was generated', () => {
+    const robotsPath = join(PUBLIC_DIR, 'robots.txt');
+    assert.ok(existsSync(robotsPath), 'robots.txt not found in public directory');
+  });
+
   after(() => {
     console.log('Cleaning up...');
     execSync('npx hexo clean', { cwd: ROOT_DIR, stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- Adds `robots.txt` file to manage crawling activities
- Configured to disallow all crawlers from accessing the site
- Prevents search engines from indexing content

## Changes
- Created `source/robots.txt` with content:
  ```
  User-agent: *
  Disallow: /
  ```
- Added test case to verify robots.txt is correctly generated

## Testing
✅ All npm test tests pass (5/5)
  - Verify robots.txt was generated in public directory
  - Verify index.html was generated
  - Verify public directory exists
  - Verify non-empty output
  - Generate site

## Impact
- Website will not be indexed by search engines
- Crawlers will be blocked from accessing all content via robots.txt protocol
- This is a common configuration for private or non-public blogs

Closes #8