### PR TITLE
Fix #11: 添加自定义图标库CSS使Eureka灯泡图标正常显示

### DIFF
--- a/_config.fluid.yml
+++ b/_config.fluid.yml
@@ -238,6 +238,7 @@ custom_js:
 # 指定自定义 .css 文件路径，用法和 custom_js 相同
 # The usage is the same as custom_js
 custom_css:
+  - //at.alicdn.com/t/c/font_5156460_d7sxrooicgj.css
 
 # 网页访问统计
 # Analysis of website visitors

--- a/_config.fluid.yml
+++ b/_config.fluid.yml
@@ -371,7 +371,7 @@ navbar:
     - { key: "home", link: "/", icon: "iconfont icon-home-fill" }
     - { key: "archive", link: "/posts/", icon: "iconfont icon-archive-fill" }
     - { key: "category", link: "/categories/", icon: "iconfont icon-category-fill" }
-    - { key: "eureka", link: "/eureka/", icon: "iconfont icon-lightbulb-fill" }
+    - { key: "eureka", link: "/eureka/", icon: "iconfont icon-a-iconlightbulbfill" }
     - { key: "tag", link: "/tags/", icon: "iconfont icon-tags-fill" }
     - { key: "about", link: "/about/", icon: "iconfont icon-user-fill" }
     - { key: "links", link: "/links/", icon: "iconfont icon-link-fill" }


### PR DESCRIPTION
## 关联Issue
Closes #11

## 修改点说明
- **文件**：`_config.fluid.yml`
- **修改内容**：
  1. 第240行 `custom_css:` 配置项：添加阿里图标库CSS文件引入
     ```yaml
     custom_css:
       - //at.alicdn.com/t/c/font_5156460_d7sxrooicgj.css
     ```
  2. 第374行navbar配置：将Eureka菜单项图标class改为 `icon-a-iconlightbulbfill`

## 影响性分析
- 影响范围：全站导航菜单
- 预期效果：Eureka菜单项的灯泡图标能够正常显示
- 风险评估：低风险，仅增加外部CSS资源，不修改现有逻辑

## npm test测试报告
```
✓ tests 5
✓ suites 1
✓ pass 5
✓ fail 0
✓ cancelled 0
✓ skipped 0
✓ todo 0
✓ duration_ms 7031.2492
```
所有测试用例通过。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)