### PR TITLE
Fix #13: Eureka通过github action从issue中生成

### DIFF
--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -1,0 +1,99 @@
+name: Eureka from Issue
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if label is "new eureka"
+        if: github.event.label.name != 'new eureka'
+        run: |
+          echo "Label is not 'new eureka', skipping"
+          exit 1
+
+      - name: Reject unauthorized user
+        if: github.event.issue.user.login != 'tongl2'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '[New Eureka Bot] Only @tongl2 is qualified to create "new eureka" issue. Please wait for maintainer to process this new eureka!'
+            });
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['tongl2']
+            });
+
+      - name: Reject unauthorized user (exit)
+        if: github.event.issue.user.login != 'tongl2'
+        run: exit 1
+
+  create-eureka:
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      filename: ${{ steps.generate-filename.outputs.filename }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate filename
+        id: generate-filename
+        run: |
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_TITLE_SANITIZED=$(echo "$ISSUE_TITLE" | sed 's/ /_/g' | sed 's/[^a-zA-Z0-9_]/_/g')
+          CREATED_AT="${{ github.event.issue.created_at }}"
+          TIMESTAMP=$(echo "$CREATED_AT" | sed 's/T/-/g' | sed 's/://g' | sed 's/-\([0-9][0-9]\)-\([0-9][0-9]\)[0-9][0-9]Z/-\1-\2-/g')
+          TIMESTAMP=$(echo "$TIMESTAMP" | cut -c1-19)
+          FILENAME="${TIMESTAMP}---${ISSUE_TITLE_SANITIZED}.txt"
+          echo "filename=$FILENAME" >> $GITHUB_OUTPUT
+          echo "Filename: $FILENAME"
+
+      - name: Create Eureka file
+        run: |
+          FILEPATH="source/_eureka/${{ steps.generate-filename.outputs.filename }}"
+          mkdir -p source/_eureka
+          echo "${{ github.event.issue.body }}" > "$FILEPATH"
+          echo "Created file: $FILEPATH"
+
+      - name: Upload file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: eureka-file
+          path: source/_eureka/${{ steps.generate-filename.outputs.filename }}
+
+  commit-and-push:
+    needs: create-eureka
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download file artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: eureka-file
+          path: source/_eureka/
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit and push
+        run: |
+          git add source/_eureka/${{ needs.create-eureka.outputs.filename }}
+          git commit -m "Add Eureka: ${{ github.event.issue.title }}"
+          git push


### PR DESCRIPTION
## Summary
- 新增 `eureka-from-issue.yml` GitHub Actions workflow
- 实现通过 issue 自动发布 Eureka 功能

## Changes
- 新增文件：`.github/workflows/eureka-from-issue.yml`
- 触发条件：当 issue 被添加 "new eureka" label 时
- 权限验证：只有 tongl2 可以创建 Eureka issue
- 文件生成：在 `source/_eureka/` 下创建 `{timestamp}---{title}.txt` 文件
- 自动提交：将文件 commit 到 main 分支，触发 Hexo 构建和部署

## Impact Analysis
- 需要确保仓库中存在 `new eureka` label
- workflow 需要 `contents: write` 和 `issues: write` 权限
- 使用 GitHub Token 进行认证，无需额外配置
- 时间戳使用 UTC 格式，与现有 Eureka 文件一致

## Testing
- 本地 npm test 通过（5 个测试用例全部通过）
- 权限拒绝逻辑需要通过创建测试 issue 验证
- 完整流程需要通过 GitHub Actions 运行验证

## Related Issue
Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)