### PR TITLE
Fix #17: 修复Eureka from Issue workflow的4个问题

### DIFF
--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -68,9 +68,9 @@ jobs:
 
       - name: Create Eureka file
         run: |
-          FILEPATH="source/_eureka/${{ steps.generate-filename.outputs.filename }}"
-          mkdir -p source/_
-eureka
+          FILEPATH="source/_eureka/${{ steps.generate-filename
+.outputs.filename }}"
+          mkdir -p source/_eureka
           echo "${{ github.event.issue.body }}" > "$FILEPATH"
           echo "Created file: $FILEPATH"
 
@@ -102,7 +102,7 @@ eureka
 
       - name: Commit and push
         run: |
-          git add source/_eureka/${{ needs.create-eureka.outputs.filename }}
+          git add source/_eureka/${{ needs.create-eureka.outputs.filename }}"
           git commit -m "Add Eureka: ${{ github.event.issue.title }}"
           git push origin main
 

--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -11,15 +11,21 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    outputs:
+      should_proceed: ${{ steps.set-flag.outputs.should_proceed }}
     steps:
       - name: Check if label is "new eureka"
-        if: github.event.label.name != 'new eureka'
+        id: set-flag
         run: |
-          echo "Label is not 'new eureka', skipping"
-          exit 1
+          if [[ "${{ github.event.label.name }}" == "new eureka" ]]; then
+            echo "should_proceed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Label is not 'new eureka', skipping"
+            echo "should_proceed=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Reject unauthorized user
-        if: github.event.issue.user.login != 'tongl2'
+        if: steps.set-flag.outputs.should_proceed == 'true' && github.event.issue.user.login != 'tongl2'
         uses: actions/github-script@v7
         with:
           script: |
@@ -37,11 +43,12 @@ jobs:
             });
 
       - name: Reject unauthorized user (exit)
-        if: github.event.issue.user.login != 'tongl2'
+        if: steps.set-flag.outputs.should_proceed == 'true' && github.event.issue.user.login != 'tongl2'
         run: exit 1
 
   create-eureka:
     needs: validate
+    if: needs.validate.outputs.should_proceed == 'true'
     runs-on: ubuntu-latest
     outputs:
       filename: ${{ steps.generate-filename.outputs.filename }}
@@ -54,8 +61,7 @@ jobs:
           ISSUE_TITLE="${{ github.event.issue.title }}"
           ISSUE_TITLE_SANITIZED=$(echo "$ISSUE_TITLE" | sed 's/ /_/g' | sed 's/[^a-zA-Z0-9_]/_/g')
           CREATED_AT="${{ github.event.issue.created_at }}"
-          TIMESTAMP=$(echo "$CREATED_AT" | sed 's/T/-/g' | sed 's/://g' | sed 's/-\([0-9][0-9]\)-\([0-9][0-9]\)[0-9][0-9]Z/-\1-\2-/g')
-          TIMESTAMP=$(echo "$TIMESTAMP" | cut -c1-19)
+          TIMESTAMP=$(echo "$CREATED_AT" | sed 's/T/-/g' | sed 's/:/-/g' | sed 's/Z//')
           FILENAME="${TIMESTAMP}---${ISSUE_TITLE_SANITIZED}.txt"
           echo "filename=$FILENAME" >> $GITHUB_OUTPUT
           echo "Filename: $FILENAME"
@@ -63,7 +69,8 @@ jobs:
       - name: Create Eureka file
         run: |
           FILEPATH="source/_eureka/${{ steps.generate-filename.outputs.filename }}"
-          mkdir -p source/_eureka
+          mkdir -p source/_
+eureka
           echo "${{ github.event.issue.body }}" > "$FILEPATH"
           echo "Created file: $FILEPATH"
 
@@ -75,6 +82,7 @@ jobs:
 
   commit-and-push:
     needs: create-eureka
+    if: needs.validate.outputs.should_proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,4 +104,9 @@ jobs:
         run: |
           git add source/_eureka/${{ needs.create-eureka.outputs.filename }}
           git commit -m "Add Eureka: ${{ github.event.issue.title }}"
-          git push
+          git push origin main
+
+      - name: Delete issue
+        if: success()
+        run: |
+          gh issue close ${{ github.event.issue.number }} --comment "Eureka created and deployed"

--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -107,5 +107,11 @@ jobs:
 
       - name: Delete issue
         if: success()
-        run: |
-          gh issue close ${{ github.event.issue.number }} --comment "Eureka created and deployed"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.delete({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });

--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -38,7 +38,7 @@ jobs:
             github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue: number: context.issue.number,
+              issue_number: context.issue.number,
               assignees: ['tongl2']
             });
 
@@ -53,7 +53,7 @@ jobs:
     outputs:
       filename: ${{ steps.generate-filename.outputs.filename }}
     steps:
-      - uses: actions: /checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Generate filename
         id: generate-filename

--- a/.github/workflows/eureka-from-issue.yml
+++ b/.github/workflows/eureka-from-issue.yml
@@ -38,7 +38,7 @@ jobs:
             github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue: number: context.issue.number,
               assignees: ['tongl2']
             });
 
@@ -53,7 +53,7 @@ jobs:
     outputs:
       filename: ${{ steps.generate-filename.outputs.filename }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions: /checkout@v4
 
       - name: Generate filename
         id: generate-filename
@@ -68,8 +68,7 @@ jobs:
 
       - name: Create Eureka file
         run: |
-          FILEPATH="source/_eureka/${{ steps.generate-filename
-.outputs.filename }}"
+          FILEPATH="source/_eureka/${{ steps.generate-filename.outputs.filename }}"
           mkdir -p source/_eureka
           echo "${{ github.event.issue.body }}" > "$FILEPATH"
           echo "Created file: $FILEPATH"
@@ -102,7 +101,7 @@ jobs:
 
       - name: Commit and push
         run: |
-          git add source/_eureka/${{ needs.create-eureka.outputs.filename }}"
+          git add source/_eureka/${{ needs.create-eureka.outputs.filename }}
           git commit -m "Add Eureka: ${{ github.event.issue.title }}"
           git push origin main
 


### PR DESCRIPTION
## 关联 issue

Fixes #17

## 修改点

1. **修复文件名时间格式生成逻辑**
   - 原问题：生成的文件名是 `2026-04-13-024656Z---Eureka_from_issue.txt`
   - 修复后：`2026-04-13-02-46-56---Eureka_from_issue.txt`
   - 修改：将复杂的时间格式转换改为简单的 `sed 's/T/-/g' | sed 's/:/-/g' | sed 's/Z//'`

2. **优化 label 检查逻辑**
   - 原问题：非 "new eureka" label 时 workflow 失败（显示红色X）
   - 修复后：优雅跳过，不显示失败
   - 修改：使用输出标志 `should_proceed`，后续 jobs 通过 `if: needs.validate.outputs.should_proceed == 'true'` 判断

3. **修复 git push 分支**
   - 原问题：`git push` 没有指定分支
   - 修复后：`git push origin main`
   - 原因：确保推送到 main 分支，触发 pages workflow

4. **添加删除 issue 步骤**
   - 原问题：文件生成后 issue 没有被删除
   - 修复后：提交成功后使用 GitHub API 删除 issue（真正删除，不是关闭）

## 影响性分析

- 修改文件：`.github/workflows/eureka-from-issue.yml`
- 影响范围：所有通过 issue 创建 Eureka 的流程
- 向后兼容：是

## 测试建议

1. 创建一个新 issue，添加 "new eureka" label，验证 workflow 正常执行
2. 创建一个新 issue，添加其他 label，验证 workflow 优雅跳过
3. 确认生成的文件名格式正确
4. 确认 pages workflow 正常触发